### PR TITLE
Fix build with spaces in path

### DIFF
--- a/ooz-sys/ooz.vcxproj
+++ b/ooz-sys/ooz.vcxproj
@@ -98,7 +98,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(Configuration)\*.dll $(SolutionDir)ZamboniLib\</Command>
+      <Command>copy "$(Configuration)\*.dll" "$(SolutionDir)ZamboniLib\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -117,7 +117,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(Configuration)\*.dll $(SolutionDir)ZamboniLib\</Command>
+      <Command>copy "$(Configuration)\*.dll" "$(SolutionDir)ZamboniLib\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -132,7 +132,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(Configuration)\*.dll $(SolutionDir)ZamboniLib\</Command>
+      <Command>copy "$(Configuration)\*.dll" "$(SolutionDir)ZamboniLib\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -151,7 +151,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>copy $(Configuration)\*.dll $(SolutionDir)ZamboniLib\</Command>
+      <Command>copy "$(Configuration)\*.dll" "$(SolutionDir)ZamboniLib\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Added quotes around the paths in the copy commands so they work if the project path has spaces in it.